### PR TITLE
Regex match for given patterns

### DIFF
--- a/ReadMe.MD
+++ b/ReadMe.MD
@@ -123,7 +123,8 @@ Cleaner uses a JSON configuration file to specify which directories and files to
     ],
     "file_extensions_to_remove": [".DS_Store", "__debug_bin"],
     "exclude_directories": [".git", ".svn"],
-    "exclude_files": []
+    "exclude_files": [],
+    "matchRegex": true
 }
 ```
 

--- a/cleaner_config.json
+++ b/cleaner_config.json
@@ -11,5 +11,6 @@
     ],
     "file_extensions_to_remove": [".DS_Store", "__debug_bin"],
     "exclude_directories": [".git", ".svn"],
-    "exclude_files": []
+    "exclude_files": [],
+    "matchRegex": true
 }

--- a/cleaner_test.go
+++ b/cleaner_test.go
@@ -25,21 +25,28 @@ func TestShouldRemoveDir(t *testing.T) {
 }
 
 func TestShouldRemoveFile(t *testing.T) {
-	extensionsToRemove := []string{".exe", ".dll", ".tmp"}
-
 	tests := []struct {
-		fileName string
-		want     bool
+		fileName   string
+		extensions []string
+		matchRegex bool
+		want       bool
 	}{
-		{"program.exe", true},
-		{"tempfile.tmp", true},
-		{"document.txt", false},
+		// Non-regex cases
+		{"program.exe", []string{".exe", ".dll", ".tmp"}, false, true},
+		{"tempfile.tmp", []string{".exe", ".dll", ".tmp"}, false, true},
+		{"document.txt", []string{".exe", ".dll", ".tmp"}, false, false},
+
+		// Regex cases
+		{"tempfile.log", []string{`temp.*\.log`}, true, true},
+		{"logfile.log", []string{`temp.*\.log`}, true, false},
+		{"debug_info.txt", []string{`debug_.*\.txt`}, true, true},
+		{"info.txt", []string{`debug_.*\.txt`}, true, false},
 	}
 
 	for _, tt := range tests {
-		got := shouldRemoveFile(tt.fileName, extensionsToRemove)
+		got := shouldRemoveFile(tt.fileName, tt.extensions, tt.matchRegex)
 		if got != tt.want {
-			t.Errorf("shouldRemoveFile(%q) = %v; want %v", tt.fileName, got, tt.want)
+			t.Errorf("shouldRemoveFile(%q, %v, %v) = %v; want %v", tt.fileName, tt.extensions, tt.matchRegex, got, tt.want)
 		}
 	}
 }
@@ -65,7 +72,6 @@ func TestIsExcluded(t *testing.T) {
 }
 
 func TestLoadConfig(t *testing.T) {
-	// Since we're not using files, we'll test getDefaultConfig instead
 	config := getDefaultConfig()
 
 	if len(config.DirectoriesToRemove) == 0 {

--- a/setup_test_env.sh
+++ b/setup_test_env.sh
@@ -12,9 +12,11 @@ mkdir -p .git bin build dist node_modules/module src
 # Create files in .git (excluded directory)
 echo "git config" > .git/config
 
-# Create files in bin (should be removed)
+# Create files in bin (should be removed with regex and non-regex patterns)
 echo "binary data" > bin/program.exe
 echo "library data" > bin/helper.dll
+echo "temporary data" > bin/temp_file.log  # Should be removed if matched by regex `temp.*\.log`
+echo "debug info" > bin/debug_info.txt     # Should be removed if matched by regex `debug_.*\.txt`
 
 # Create files in build (should be removed)
 echo "object file data" > build/output.o
@@ -33,8 +35,12 @@ touch src/.DS_Store  # Should be removed
 # Create root-level files
 echo "ENV variables" > .env  # Should not be removed
 echo "Project documentation" > README.md  # Should not be removed
-touch .DS_Store  # Should be removed
-touch __debug_bin  # Should be removed
+touch .DS_Store       # Should be removed
+touch __debug_bin     # Should be removed
+touch ___debug_bin_1100     # Should be removed
+touch app__debug_bin     # Should be removed
+touch tempfile.log    # Should be removed if matched by regex `temp.*\.log`
+touch debug_output.txt # Should be removed if matched by regex `debug_.*\.txt`
 
 # Navigate back to the parent directory
 cd ..

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Create Setup Test Environment
+echo "Setting up Test Environment"
+./setup_test_env.sh
+
+# Run the main script
+echo "Running Test Script"
+go run main.go test_project
+
+# Clean up the test environment
+echo "Cleaning up Test Environment"
+rm -rf test_project
+rm cleaned_source.txt
+
+# Done
+echo "Test Completed"


### PR DESCRIPTION
# What's Done ✅ 

- Implemented new regex match feature to match `file_extensions_to_remove` based on `matchRegex` flag
- New `cleaner_config.json` should look like following
- Now `matchRegex` is default to `true` removing all matched files.

```json
{
    "directories_to_remove": [
        "node_modules",
        "dist",
        "build",
        "bin",
        ".next",
        ".turbo",
        ".idea",
        ".cache"
    ],
    "file_extensions_to_remove": [".DS_Store", "__debug_bin"],
    "exclude_directories": [".git", ".svn"],
    "exclude_files": [],
    "matchRegex": true
}
```

## Tickets closed 

- closes #1  